### PR TITLE
feat: expose experiment tags on the execution event

### DIFF
--- a/go/event_kit_api/CHANGELOG.md
+++ b/go/event_kit_api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.3
+
+- Added `tags` to `ExperimentExecution`, exposing the experiment's tags at the time the execution was requested.
+
 ## 1.6.2
 
 - Update dependencies

--- a/go/event_kit_api/event_kit_api.go
+++ b/go/event_kit_api/event_kit_api.go
@@ -158,6 +158,9 @@ type ExperimentExecution struct {
 	ReasonDetails *string                  `json:"reasonDetails,omitempty"`
 	StartedTime   time.Time                `json:"startedTime"`
 	State         ExperimentExecutionState `json:"state"`
+
+	// Tags Tags of the experiment at the time the execution was requested.
+	Tags *[]string `json:"tags,omitempty"`
 }
 
 // ExperimentExecutionState defines model for ExperimentExecution.State.

--- a/openapi/spec.yml
+++ b/openapi/spec.yml
@@ -175,6 +175,12 @@ components:
           type: string
         hypothesis:
           type: string
+        tags:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+          description: Tags of the experiment at the time the execution was requested.
         preparedTime:
           type: string
           format: date-time


### PR DESCRIPTION
Adds tags to ExperimentExecution so event consumers can see the experiment's tags at the time the execution was requested. Regenerates the Go types.